### PR TITLE
Fix issue #2

### DIFF
--- a/Conversion of Galvanometer to Ammeter (Simulator)_files/simcontrols.js.download
+++ b/Conversion of Galvanometer to Ammeter (Simulator)_files/simcontrols.js.download
@@ -216,6 +216,7 @@ window.onload = function() {
 		}
 		function addintoDropDown(getId,valueSet){//Function for adding option in combo box---		
 			var selected = getId;
+        selected.empty(); // Clear old options to prevent duplication
 			$.each(valueSet, function(val, text) {
 			selected.append($('<option></option>').val(val).html(text));});			
 		}

--- a/Conversion of Galvanometer to Ammeter (Simulator)_files/simcontrols.js.download
+++ b/Conversion of Galvanometer to Ammeter (Simulator)_files/simcontrols.js.download
@@ -216,7 +216,7 @@ window.onload = function() {
 		}
 		function addintoDropDown(getId,valueSet){//Function for adding option in combo box---		
 			var selected = getId;
-        selected.empty(); // Clear old options to prevent duplication
+        	selected.empty(); // Clear old options to prevent duplication
 			$.each(valueSet, function(val, text) {
 			selected.append($('<option></option>').val(val).html(text));});			
 		}

--- a/Diode characteristics (Simulator)_files/simcontrols.js.download
+++ b/Diode characteristics (Simulator)_files/simcontrols.js.download
@@ -50,6 +50,7 @@ window.onload = function init(){// function called on loading..
 		addintoDropDown($('#Diodetype2'),Combo_vals[1]);	
 		$('#popup_txt').html(gt.gettext("Insert key"));
 		function addintoDropDown(getId,valueSet){//Function to add values into combobox------
+			selected.empty();
 			$.each(valueSet, function(val, text) {getId.append($('<option ></option>').val(val).html(text));});
 		}
 		$(".dropBox").change(function(){//combo box change 

--- a/Figure of Merit of a galvanometer (Simulator)_files/saved_resource_files/simcontrols.js.download
+++ b/Figure of Merit of a galvanometer (Simulator)_files/saved_resource_files/simcontrols.js.download
@@ -56,6 +56,7 @@ window.onload = function init(){// function called on loading..
 		$("#resistance_frm :input,#Insrtkey1,#Insrtkey2,#showAns").prop("disabled", true);
 		addintoDropDown($('#Galvanotype'),Galvanomtr_type);		
 		function addintoDropDown(getId,valueSet){//Function to add values into combobox------
+			selected.empty();
 			$.each(valueSet, function(val, text) {getId.append($('<option ></option>').val(val).html(text));});
 		}
 		for(var k=0;k<4;k++){

--- a/Metre Bridge-Resistance of a wire (Simulator)_files/saved_resource_files/simcontrols.js.download
+++ b/Metre Bridge-Resistance of a wire (Simulator)_files/saved_resource_files/simcontrols.js.download
@@ -46,6 +46,7 @@ window.onload = function init(){
   /** Adding connection options to the drop down list */
   function addintoDropDown(getId,valueSet){	
 	var _selected = getId;
+	selected.empty();
 	$.each(valueSet, function(val, text){
 	  _selected.append(
 	    $('<option></option>').val(val).html(text)

--- a/Metre bridge- Law of combination of resistors (Simulator (Paralell))_files/saved_resource_files/simcontrols.js.download
+++ b/Metre bridge- Law of combination of resistors (Simulator (Paralell))_files/saved_resource_files/simcontrols.js.download
@@ -86,6 +86,7 @@ window.onload = function init(){
   /** Adding items to the drop down list */
   function addintoDropDown(getId,valueSet){	
 	var _selected = getId;
+	selected.empty();
 	$.each(valueSet, function(val, text){
 	  _selected.append(
 	    $('<option></option>').val(val).html(text)

--- a/Metre bridge- Law of combination of resistors (Simulator (Series))_files/saved_resource_files/simcontrols.js.download
+++ b/Metre bridge- Law of combination of resistors (Simulator (Series))_files/saved_resource_files/simcontrols.js.download
@@ -46,6 +46,7 @@ window.onload = function init(){
   /** Adding connection options to the drop down list */
   function addintoDropDown(getId,valueSet){	
 	var _selected = getId;
+	selected.empty();
 	$.each(valueSet, function(val, text){
 	  _selected.append(
 	    $('<option></option>').val(val).html(text)

--- a/Ohm's law and resistance (Simulator)_files/saved_resource_files/simcontrols.js.download
+++ b/Ohm's law and resistance (Simulator)_files/saved_resource_files/simcontrols.js.download
@@ -88,6 +88,7 @@ window.onload = function init(){
 		addintoDropDown($('#selectMetal'),metals);		
 		//-------Function to add values into combobox------
 		function addintoDropDown(getId,valueSet){
+			selected.empty();
 			$.each(valueSet, function(val, text) {
 				getId.append(
 					$('<option ></option>').val(val).html(text) 

--- a/Transistor characteristics (Simulator)_files/saved_resource_files/simcontrols.js.download
+++ b/Transistor characteristics (Simulator)_files/saved_resource_files/simcontrols.js.download
@@ -107,6 +107,7 @@ window.onload = function() {
 		}
 		function addintoDropDown(getId,valueSet){//Function for adding option in combo box---		
 			var selected = getId;
+			selected.empty();
 			$.each(valueSet, function(val, text) {
 			selected.append($('<option></option>').val(val).html(text));});			
 		}

--- a/Zener Diode (Simulator)_files/saved_resource_files/simcontrols.js.download
+++ b/Zener Diode (Simulator)_files/saved_resource_files/simcontrols.js.download
@@ -89,6 +89,7 @@ window.onload = function() {
 		}
 		function addintoDropDown(getId,valueSet){//Function for adding option in combo box---		
 			var selected = getId;
+			selected.empty();
 			$.each(valueSet, function(val, text) {
 			selected.append($('<option></option>').val(val).html(text));});			
 		}


### PR DESCRIPTION
This PR resolves the issue of duplicate range entries in the dropdown menu by clearing old options before appending new ones.

**Changes Made:**
- Added `selected.empty();` before populating the dropdown to remove previously added options.
- This prevents range values from being duplicated each time the dropdown updates.

**File Modified:**  
_simcontrols.js_

**Why this fix matters:**  
- Prevents UI clutter and confusion from duplicate entries.  
- Ensures a clean and accurate user experience when interacting with the simulator.

Fixes #2 
